### PR TITLE
[PREAM-31] Input 컴포넌트 구현

### DIFF
--- a/src/components/input/index.stories.tsx
+++ b/src/components/input/index.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Input } from '@/components/input';
+
+const meta = {
+  title: 'Components/Input',
+  component: Input,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: '판매 희망가',
+    placeholder: '판매 희망가를 입력해 주세요.',
+  },
+};
+
+export const Focused: Story = {
+  args: {
+    label: '판매 희망가',
+    autoFocus: true,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    label: '판매 희망가',
+    errorMessage: '최소 판매 가격은 100원입니다.',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: '판매 희망가',
+    disabled: true,
+  },
+};

--- a/src/components/input/index.styles.ts
+++ b/src/components/input/index.styles.ts
@@ -1,0 +1,37 @@
+import theme from '@/styles/theme';
+import { css } from '@emotion/react';
+
+export const wrapper = css`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const label = css`
+  margin-bottom: 6px;
+`;
+
+export const input = ({ errorMessage }: { errorMessage?: string }) => css`
+  width: 100%;
+  padding: 10px 12px;
+  ${theme.typo.body5};
+
+  border-bottom: ${errorMessage
+    ? `1px solid ${theme.colors.red100}`
+    : `1px solid ${theme.colors.gray200}`};
+
+  &:focus {
+    border-bottom: ${errorMessage
+      ? `1px solid ${theme.colors.red100}`
+      : `1px solid ${theme.colors.green200}`};
+  }
+
+  &::placeholder {
+    color: ${theme.colors.gray200};
+  }
+`;
+
+export const error = css`
+  margin: 5px 0 0 0;
+  padding: 0 12px;
+`;

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -1,0 +1,64 @@
+import React, { forwardRef, InputHTMLAttributes, useRef } from 'react';
+import { input, wrapper, label as labelCss, error } from './index.styles';
+import { Text } from '@/components/text';
+import theme from '@/styles/theme';
+
+export interface IInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  icon?: {
+    prefix?: React.ReactElement;
+    suffix?: React.ReactElement;
+  };
+  errorMessage?: string;
+}
+
+export const Input = forwardRef<HTMLInputElement, IInputProps>(
+  ({
+    type = 'text',
+    label,
+    disabled,
+    spellCheck = false,
+    autoComplete = 'off',
+    icon,
+    errorMessage,
+    ...rest
+  }) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    return (
+      <div css={wrapper}>
+        {label && (
+          <Text typo="subtitle2" css={labelCss}>
+            {label}
+          </Text>
+        )}
+
+        <div
+          onClick={() => {
+            if (inputRef.current) inputRef.current.focus();
+          }}
+        >
+          {icon && icon.prefix}
+          <input
+            ref={inputRef}
+            type={type}
+            spellCheck={spellCheck}
+            autoComplete={autoComplete}
+            disabled={disabled}
+            css={input({ errorMessage })}
+            {...rest}
+          />
+          {icon && icon.suffix}
+        </div>
+
+        {errorMessage && (
+          <div css={error}>
+            <Text typo="body6" color={theme.colors.red100}>
+              {errorMessage}
+            </Text>
+          </div>
+        )}
+      </div>
+    );
+  }
+);

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,4 +1,5 @@
 import { colors } from '@/styles/colors';
+import { typography } from '@/styles/typography';
 
 const theme = {
   colors,
@@ -15,6 +16,7 @@ const theme = {
     bottomSheet: 30,
     modal: 40,
   },
+  typo: { ...typography },
 } as const;
 
 export default theme;


### PR DESCRIPTION
### PR 제목

[PREAM-31] Input 컴포넌트 구현

### 🔗 연관된 이슈 번호

close #32 

### ✨ 어떤 기능을 개발했나요?
- Input 컴포넌트를 구현했습니다.

### ✅ 어떤 문제를 해결했나요?
- 사용 방법은 본래의 `<input>`을 사용할 때와 같습니다.
  ```javascript
   <Input type="text" autofocus value={value} onChange={onChange} />
  ```



[PREAM-31]: https://team-pream.atlassian.net/browse/PREAM-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ