### PR TITLE
[PREAM-120] GNB 컴포넌트에서 좋아요 탭 제거

### DIFF
--- a/src/components/gnb/index.tsx
+++ b/src/components/gnb/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { ROUTE_PATHS } from '@/constants/routes';
-import { GnbCategory, GnbHome, GnbMy, LikeOff } from '@/assets/icons';
+import { GnbCategory, GnbHome, GnbMy } from '@/assets/icons';
 import { menuItem, wrapper } from './index.styles';
 import { Text } from '@/components';
 import theme from '@/styles/theme';
@@ -16,7 +16,6 @@ const MENUS = [
     icon: <GnbCategory width="20px" height="20px" />,
     path: ROUTE_PATHS.CATEGORY,
   },
-  { name: '찜', icon: <LikeOff width="20px" height="20px" />, path: ROUTE_PATHS.LIKE },
   { name: '마이', icon: <GnbMy width="20px" height="20px" />, path: ROUTE_PATHS.MYPAGE },
 ];
 


### PR DESCRIPTION
### PR 제목

[PREAM-120] GNB 컴포넌트에서 좋아요 탭 제거

### 🔗 연관된 이슈 번호

close #49 

### ✨ 어떤 기능을 개발했나요?
- GNB 탭에서 좋아요 탭을 제거했습니다.

### ✅ 어떤 문제를 해결했나요?
- 좋아요 기능의 우선순위가 미뤄지면서 GNB 탭에서 좋아요 탭을 제거했습니다.


[PREAM-120]: https://team-pream.atlassian.net/browse/PREAM-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ