### PR TITLE
[PREAM-163] 결제 실패 페이지 화면 구현

### DIFF
--- a/public/icons/failure_icon.svg
+++ b/public/icons/failure_icon.svg
@@ -1,0 +1,5 @@
+<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="35" cy="35" r="34.5" stroke="#FA2626"/>
+<path d="M24 46L46 24" stroke="#FA2626" stroke-linejoin="round"/>
+<path d="M24 24L46 46" stroke="#FA2626" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/FailureIcon.tsx
+++ b/src/assets/icons/FailureIcon.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import type { SVGProps } from 'react';
+const SvgFailureIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 70 70" {...props}>
+    <circle cx={35} cy={35} r={34.5} stroke="#FA2626" />
+    <path stroke="#FA2626" strokeLinejoin="round" d="m24 46 22-22M24 24l22 22" />
+  </svg>
+);
+export default SvgFailureIcon;

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -4,6 +4,7 @@ export { default as DropdownFold } from './DropdownFold';
 export { default as DropdownUnfold } from './DropdownUnfold';
 export { default as EmotionalPetIcon } from './EmotionalPetIcon';
 export { default as FabPlus } from './FabPlus';
+export { default as FailureIcon } from './FailureIcon';
 export { default as GnbCategory } from './GnbCategory';
 export { default as GnbHome } from './GnbHome';
 export { default as GnbMy } from './GnbMy';

--- a/src/pages/orders/pages/complete/index.tsx
+++ b/src/pages/orders/pages/complete/index.tsx
@@ -30,7 +30,7 @@ export default function OrderComplete() {
           <Complete css={completeIcon} />
           <Text typo="title1">구매 완료!</Text>
           <Button
-            variant="box"
+            shape="box"
             size="s"
             onClick={() => {
               navigate('/');

--- a/src/pages/orders/pages/failure/index.styles.ts
+++ b/src/pages/orders/pages/failure/index.styles.ts
@@ -1,0 +1,19 @@
+import { css } from '@emotion/react';
+
+export const failureWrapper = css`
+  width: 100%;
+  height: 90vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const text = css`
+  margin: 35px 0 16px 0;
+`;
+
+export const failureIcon = css`
+  width: 70px;
+  height: 70px;
+`;

--- a/src/pages/orders/pages/failure/index.tsx
+++ b/src/pages/orders/pages/failure/index.tsx
@@ -1,3 +1,33 @@
+import { AppBarBack, FailureIcon } from '@/assets/icons';
+import { AppBar, Layout, Text } from '@/components';
+import theme from '@/styles/theme';
+import { failureIcon, failureWrapper, text } from './index.styles';
+import { useNavigate } from 'react-router-dom';
+
 export default function Failure() {
-  return <></>;
+  const navigate = useNavigate();
+  return (
+    <Layout>
+      <AppBar
+        prefix={
+          <AppBarBack
+            height="24px"
+            cursor="pointer"
+            onClick={() => {
+              navigate(-1);
+            }}
+          />
+        }
+      />
+      <div css={failureWrapper}>
+        <FailureIcon css={failureIcon} />
+        <Text typo="title1" css={text}>
+          결제 실패
+        </Text>
+        <Text typo="body4" color={theme.colors.gray300}>
+          이전으로 돌아가서 다시 시도해주세요
+        </Text>
+      </div>
+    </Layout>
+  );
 }


### PR DESCRIPTION
### PR 제목

[PREAM-163] 결제 실패 페이지 화면 구현

### 🔗 연관된 이슈 번호

close #121 

### ✨ 어떤 기능을 개발했나요?
- 결제 실패 페이지를 개발했습니다.

### ✅ 어떤 문제를 해결했나요?

### 🗂️ 관련 논의 내용 Link (Option)

### 🚀 결과 이미지 (Option)
<img width="443" alt="image" src="https://github.com/user-attachments/assets/e889820e-be07-46d1-9fc5-150b77992864">


[PREAM-163]: https://team-pream.atlassian.net/browse/PREAM-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ