### PR TITLE
[PREAM-145] 온보딩 페이지 디자인 수정

### DIFF
--- a/src/pages/onboarding/components/completion/index.styles.ts
+++ b/src/pages/onboarding/components/completion/index.styles.ts
@@ -6,6 +6,6 @@ export const textBox = css`
   justify-content: center;
   align-items: center;
   text-align: center;
-  margin-top: 250px;
+  margin-top: 45%;
   gap: 30px;
 `;

--- a/src/pages/onboarding/components/completion/index.styles.ts
+++ b/src/pages/onboarding/components/completion/index.styles.ts
@@ -6,6 +6,8 @@ export const textBox = css`
   justify-content: center;
   align-items: center;
   text-align: center;
-  margin-top: 45%;
-  gap: 30px;
+  width: 100%;
+  height: 80vh;
+  gap: 35px;
+  padding: 0 18px;
 `;

--- a/src/pages/onboarding/components/completion/index.tsx
+++ b/src/pages/onboarding/components/completion/index.tsx
@@ -16,12 +16,13 @@ export default function Completion() {
     <div css={textBox}>
       <Complete width="70px" />
       <Text typo="title1" color={theme.colors.green200}>
-        {data.nickname} 님<br />
+        {data?.nickname}{' '}
         <Text typo="title1" color={theme.colors.black}>
+          님<br />
           회원가입이 완료됐어요!
         </Text>
       </Text>
-      <Button size="l" onClick={handleCompleteButtonClick}>
+      <Button size="xl" onClick={handleCompleteButtonClick}>
         시작하기
       </Button>
     </div>

--- a/src/pages/onboarding/components/pet-name/index.styles.ts
+++ b/src/pages/onboarding/components/pet-name/index.styles.ts
@@ -4,7 +4,7 @@ export const inputWrapper = css`
   display: flex;
   flex-direction: column;
   gap: 20px;
-  margin-top: 20px;
+  margin-top: 5%;
   padding: 40px;
 `;
 
@@ -14,7 +14,7 @@ export const textBox = css`
   justify-content: center;
   align-items: center;
   text-align: center;
-  margin: 200px 0 55px 0;
+  margin: 45% 0 18% 0;
   gap: 8px;
 `;
 

--- a/src/pages/onboarding/components/pet-name/index.styles.ts
+++ b/src/pages/onboarding/components/pet-name/index.styles.ts
@@ -1,11 +1,14 @@
+import theme from '@/styles/theme';
 import { css } from '@emotion/react';
 
-export const inputWrapper = css`
+export const wrapper = css`
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  margin-top: 5%;
-  padding: 40px;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  padding: 0 18px;
 `;
 
 export const textBox = css`
@@ -14,15 +17,34 @@ export const textBox = css`
   justify-content: center;
   align-items: center;
   text-align: center;
-  margin: 45% 0 18% 0;
+  margin: 103px 0;
   gap: 8px;
 `;
 
-export const fixedButtonWrapper = css`
+export const buttonWrapper = css`
   position: fixed;
-  bottom: 73px;
-  left: 0;
+  bottom: 10px;
+  margin: 0 auto;
+  z-index: ${theme.zIndex.gnb};
   width: 100%;
+  max-width: ${theme.size.maxWidth};
+  padding: 0 18px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+`;
+
+export const skipButton = css`
+  position: relative;
+  bottom: 1%;
   display: flex;
   justify-content: center;
+  align-items: center;
+  background-color: ${theme.colors.white};
+  color: ${theme.colors.gray300};
+  width: 100%;
+  height: 45px;
+  border-radius: 10px;
+  font-weight: 700;
+  font-size: 12px;
 `;

--- a/src/pages/onboarding/components/pet-name/index.tsx
+++ b/src/pages/onboarding/components/pet-name/index.tsx
@@ -1,19 +1,24 @@
-import { inputWrapper, textBox, fixedButtonWrapper } from './index.styles';
+import { textBox, buttonWrapper, skipButton, wrapper } from './index.styles';
 import { Text, Input, Button } from '@/components';
 import theme from '@/styles/theme';
 import { UserInfoForm } from '../../types';
+import { ChangeEvent } from 'react';
 
 interface PetNameProps {
   formData: UserInfoForm;
   setFormData: (data: UserInfoForm) => void;
   onComplete: () => void;
+  onSkip: () => void;
 }
 
-export default function PetName({ formData, setFormData, onComplete }: PetNameProps) {
-  const isPetNameValid = formData.petName;
+export default function PetName({ formData, setFormData, onComplete, onSkip }: PetNameProps) {
+  const isPetNameValid = formData.petName.length >= 2 && formData.petName.length <= 20;
+  const handlePetNameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, petName: event.target.value });
+  };
 
   return (
-    <div css={inputWrapper}>
+    <div css={wrapper}>
       <div css={textBox}>
         <Text typo="title1" color={theme.colors.green200}>
           반려동물{' '}
@@ -28,19 +33,22 @@ export default function PetName({ formData, setFormData, onComplete }: PetNamePr
       <Input
         type="text"
         label="반려동물 이름"
-        placeholder="1~8자 이내로 작성해주세요"
+        placeholder="반려동물의 이름을 입력해주세요."
         value={formData.petName}
-        onChange={(e) => setFormData({ ...formData, petName: e.target.value })}
+        onChange={handlePetNameChange}
       ></Input>
-      <div css={fixedButtonWrapper}>
+      <div css={buttonWrapper}>
         <Button
-          size="l"
+          size="xl"
           status={isPetNameValid ? 'active' : 'disabled'}
           onClick={onComplete}
           disabled={!isPetNameValid}
         >
           다음
         </Button>
+        <div css={skipButton} onClick={onSkip}>
+          <Text typo="body1">건너뛰기</Text>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/onboarding/components/pet-name/index.tsx
+++ b/src/pages/onboarding/components/pet-name/index.tsx
@@ -2,7 +2,7 @@ import { textBox, buttonWrapper, skipButton, wrapper } from './index.styles';
 import { Text, Input, Button } from '@/components';
 import theme from '@/styles/theme';
 import { UserInfoForm } from '../../types';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useState } from 'react';
 
 interface PetNameProps {
   formData: UserInfoForm;
@@ -12,9 +12,22 @@ interface PetNameProps {
 }
 
 export default function PetName({ formData, setFormData, onComplete, onSkip }: PetNameProps) {
-  const isPetNameValid = formData.petName.length >= 2 && formData.petName.length <= 20;
+  const [isPetNameValid, setIsPetNameVaild] = useState<boolean>(false);
+  const [nameErrorMessage, setNameErrorMessage] = useState<string>('');
   const handlePetNameChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setFormData({ ...formData, petName: event.target.value });
+    const value = event.target.value;
+    if (value.length > 20) {
+      return;
+    }
+    if (!value || value.length < 1) {
+      setIsPetNameVaild(false);
+      setNameErrorMessage('1~20자 이내로 입력해주세요');
+    } else {
+      setIsPetNameVaild(true);
+      setNameErrorMessage('');
+    }
+    console.log(value);
+    setFormData({ ...formData, petName: value });
   };
 
   return (
@@ -36,6 +49,7 @@ export default function PetName({ formData, setFormData, onComplete, onSkip }: P
         placeholder="반려동물의 이름을 입력해주세요."
         value={formData.petName}
         onChange={handlePetNameChange}
+        errorMessage={nameErrorMessage}
       ></Input>
       <div css={buttonWrapper}>
         <Button

--- a/src/pages/onboarding/components/pet-name/index.tsx
+++ b/src/pages/onboarding/components/pet-name/index.tsx
@@ -26,7 +26,6 @@ export default function PetName({ formData, setFormData, onComplete, onSkip }: P
       setIsPetNameVaild(true);
       setNameErrorMessage('');
     }
-    console.log(value);
     setFormData({ ...formData, petName: value });
   };
 

--- a/src/pages/onboarding/components/pet-type/index.styles.ts
+++ b/src/pages/onboarding/components/pet-type/index.styles.ts
@@ -6,7 +6,7 @@ export const wrapper = css`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 0 18px;
+  padding: 12% 4% 0 4%;
 `;
 
 export const textBox = css`
@@ -15,7 +15,7 @@ export const textBox = css`
   justify-content: center;
   align-items: center;
   text-align: center;
-  margin: 20px 0 44px 0;
+  margin: 0 0 18% 0;
   gap: 8px;
 `;
 
@@ -54,24 +54,9 @@ export const selectBox = (isSelected: boolean) => css`
   }
 `;
 
-export const skipButton = css`
-  position: absolute;
-  bottom: 23px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: ${theme.colors.white};
-  color: ${theme.colors.gray300};
-  width: 354px;
-  height: 45px;
-  border-radius: 10px;
-  font-weight: 700;
-  font-size: 12px;
-`;
-
 export const fixedButtonWrapper = css`
   position: fixed;
-  bottom: 73px;
+  bottom: 7.5%;
   left: 0;
   width: 100%;
   display: flex;

--- a/src/pages/onboarding/components/pet-type/index.styles.ts
+++ b/src/pages/onboarding/components/pet-type/index.styles.ts
@@ -6,7 +6,9 @@ export const wrapper = css`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 12% 4% 0 4%;
+  width: 100%;
+  height: 100%;
+  padding: 0 18px;
 `;
 
 export const textBox = css`
@@ -15,8 +17,12 @@ export const textBox = css`
   justify-content: center;
   align-items: center;
   text-align: center;
-  margin: 0 0 18% 0;
+  margin: 103px 0;
   gap: 8px;
+`;
+
+export const text = css`
+  margin-bottom: 30px;
 `;
 
 export const selectContainer = css`
@@ -43,7 +49,7 @@ export const selectBox = (isSelected: boolean) => css`
   align-items: center;
   flex-direction: column;
   gap: 17px;
-  background-color: ${theme.colors.gray100};
+  background-color: ${isSelected ? theme.colors.green100 : theme.colors.gray100};
   border: 1px solid ${isSelected ? theme.colors.green200 : theme.colors.gray200};
   color: ${theme.colors.gray300};
 
@@ -54,11 +60,30 @@ export const selectBox = (isSelected: boolean) => css`
   }
 `;
 
-export const fixedButtonWrapper = css`
+export const buttonWrapper = css`
   position: fixed;
-  bottom: 7.5%;
-  left: 0;
+  bottom: 10px;
+  margin: 0 auto;
+  z-index: ${theme.zIndex.gnb};
   width: 100%;
+  max-width: ${theme.size.maxWidth};
+  padding: 0 18px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+`;
+
+export const skipButton = css`
+  position: relative;
+  bottom: 1%;
   display: flex;
   justify-content: center;
+  align-items: center;
+  background-color: ${theme.colors.white};
+  color: ${theme.colors.gray300};
+  width: 100%;
+  height: 45px;
+  border-radius: 10px;
+  font-weight: 700;
+  font-size: 12px;
 `;

--- a/src/pages/onboarding/components/pet-type/index.tsx
+++ b/src/pages/onboarding/components/pet-type/index.tsx
@@ -1,10 +1,11 @@
 import {
-  selectContainer,
   selectBox,
-  fixedButtonWrapper,
   selectZone,
   textBox,
   wrapper,
+  buttonWrapper,
+  skipButton,
+  text,
 } from './index.styles';
 import { SelectCat, SelectDog } from '@/assets/icons';
 import { Text, Button } from '@/components';
@@ -16,57 +17,59 @@ interface PetTypeProps {
   formData: UserInfoForm;
   setFormData: (data: UserInfoForm) => void;
   onNext: () => void;
+  onSkip: () => void;
 }
 
-export default function PetType({ formData, setFormData, onNext }: PetTypeProps) {
+export default function PetType({ formData, setFormData, onNext, onSkip }: PetTypeProps) {
   const { data } = useGetUsersMeQuery();
   const isPetTypeValid = formData.petType !== null;
 
   return (
-    <section css={wrapper}>
-      <div css={selectContainer}>
-        <div css={textBox}>
-          <Text typo="title1" color={theme.colors.black}>
-            반가워요{' '}
-            <Text typo="title1" color={theme.colors.green200}>
-              {data?.nickname}{' '}
-            </Text>
-            님!
+    <div css={wrapper}>
+      <div css={textBox}>
+        <Text typo="title1" color={theme.colors.black}>
+          반가워요{' '}
+          <Text typo="title1" color={theme.colors.green200}>
+            {data?.nickname}{' '}
           </Text>
-          <Text typo="body4" color={theme.colors.gray300}>
-            당신과 함께하는 친구가 궁금해요!
-          </Text>
-        </div>
-        <Text typo="body4" color={theme.colors.black}>
-          어떤 반려동물과 함께 하고 있나요?
+          님!
         </Text>
-        <div css={selectZone}>
-          <div
-            css={selectBox(formData.petType === PET_TYPE.DOG)}
-            onClick={() => setFormData({ ...formData, petType: PET_TYPE.DOG })}
-          >
-            <SelectDog width="120px" />
-            <Text typo="body1">강아지</Text>
-          </div>
-          <div
-            css={selectBox(formData.petType === PET_TYPE.CAT)}
-            onClick={() => setFormData({ ...formData, petType: PET_TYPE.CAT })}
-          >
-            <SelectCat width="120px" />
-            <Text typo="body1">고양이</Text>
-          </div>
+        <Text typo="body4" color={theme.colors.gray300}>
+          당신과 함께하는 친구가 궁금해요!
+        </Text>
+      </div>
+      <Text typo="body4" color={theme.colors.black} css={text}>
+        어떤 반려동물과 함께 하고 있나요?
+      </Text>
+      <div css={selectZone}>
+        <div
+          css={selectBox(formData.petType === PET_TYPE.DOG)}
+          onClick={() => setFormData({ ...formData, petType: PET_TYPE.DOG })}
+        >
+          <SelectDog width="120px" />
+          <Text typo="body1">강아지</Text>
         </div>
-        <div css={fixedButtonWrapper}>
-          <Button
-            size="l"
-            status={isPetTypeValid ? 'active' : 'disabled'}
-            onClick={onNext}
-            disabled={!isPetTypeValid}
-          >
-            다음
-          </Button>
+        <div
+          css={selectBox(formData.petType === PET_TYPE.CAT)}
+          onClick={() => setFormData({ ...formData, petType: PET_TYPE.CAT })}
+        >
+          <SelectCat width="120px" />
+          <Text typo="body1">고양이</Text>
         </div>
       </div>
-    </section>
+      <div css={buttonWrapper}>
+        <Button
+          size="xl"
+          status={isPetTypeValid ? 'active' : 'disabled'}
+          onClick={onNext}
+          disabled={!isPetTypeValid}
+        >
+          다음
+        </Button>
+        <div css={skipButton} onClick={onSkip}>
+          <Text typo="body1">건너뛰기</Text>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/pages/onboarding/components/user-info/index.styles.ts
+++ b/src/pages/onboarding/components/user-info/index.styles.ts
@@ -1,3 +1,4 @@
+import theme from '@/styles/theme';
 import { css } from '@emotion/react';
 
 export const wrapper = css`
@@ -5,8 +6,17 @@ export const wrapper = css`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 12% 4% 0 4%;
+  width: 100%;
+  height: 100%;
+  padding: 0 18px;
+`;
+
+export const formWrapper = css`
+  width: 100%;
+  height: 100%;
   gap: 26px;
+  display: flex;
+  flex-direction: column;
 `;
 
 export const textBox = css`
@@ -15,15 +25,19 @@ export const textBox = css`
   justify-content: center;
   align-items: center;
   text-align: center;
-  margin: 0 0 18% 0;
+  margin: 103px 0;
   gap: 8px;
 `;
 
-export const fixedButtonWrapper = css`
+export const buttonWrapper = css`
   position: fixed;
-  bottom: 2%;
-  left: 0;
+  bottom: 10px;
+  margin: 0 auto;
+  z-index: ${theme.zIndex.gnb};
   width: 100%;
+  max-width: ${theme.size.maxWidth};
+  padding: 0 18px;
   display: flex;
-  justify-content: center;
+  align-items: center;
+  flex-direction: column;
 `;

--- a/src/pages/onboarding/components/user-info/index.styles.ts
+++ b/src/pages/onboarding/components/user-info/index.styles.ts
@@ -5,7 +5,7 @@ export const wrapper = css`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 48px 18px 0 18px;
+  padding: 12% 4% 0 4%;
   gap: 26px;
 `;
 
@@ -15,13 +15,13 @@ export const textBox = css`
   justify-content: center;
   align-items: center;
   text-align: center;
-  margin: 0 0 60px 0;
+  margin: 0 0 18% 0;
   gap: 8px;
 `;
 
 export const fixedButtonWrapper = css`
   position: fixed;
-  bottom: 23px;
+  bottom: 2%;
   left: 0;
   width: 100%;
   display: flex;

--- a/src/pages/onboarding/components/user-info/index.tsx
+++ b/src/pages/onboarding/components/user-info/index.tsx
@@ -37,7 +37,7 @@ export default function UserInfo({ onNext, setFormData, formData }: UserInfoProp
 
     const nickname = formData.nickname.trim(); //공백 제거
     if (!nickname || nickname.length < 2 || nickname.length > 20) {
-      setNicknameErrorMessage('닉네임은 최소 2자, 최대 20자로 입력해주세요.');
+      setNicknameErrorMessage('닉네임은 2~20자 이내로 입력해주세요.');
       setIsValidNickname(false);
       return;
     }

--- a/src/pages/onboarding/components/user-info/index.tsx
+++ b/src/pages/onboarding/components/user-info/index.tsx
@@ -15,8 +15,15 @@ interface UserInfoProps {
 
 export default function UserInfo({ onNext, setFormData, formData }: UserInfoProps) {
   const [nicknameAvailable, setNicknameAvailable] = useState<boolean | null>(null);
+  const [phoneError, setPhoneError] = useState('');
+  const [emailError, setEmailError] = useState(''); // 이메일 오류 상태 추가
   const isUserInfoValid =
-    formData.email && formData.nickname && formData.phone && nicknameAvailable;
+    formData.email &&
+    formData.nickname &&
+    formData.phone &&
+    nicknameAvailable &&
+    !emailError &&
+    !phoneError;
 
   const { mutate: patchUsersOnboarding } = usePatchUsersOnboardingMutation(onNext);
   const checkNicknameMutation = usePostUsersCheckNicknameMutation(() => {
@@ -33,6 +40,34 @@ export default function UserInfo({ onNext, setFormData, formData }: UserInfoProp
       setNicknameAvailable(true);
     } catch {
       setNicknameAvailable(false);
+    }
+  };
+
+  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+
+    // 유효성 검사
+    const phoneRegex = /^010-\d{4}-\d{4}$/; // 형식 검사를 위한 정규식 (010-XXXX-XXXX 형식)
+
+    setFormData({ ...formData, phone: value });
+
+    if (!phoneRegex.test(value)) {
+      setPhoneError('휴대폰 번호는 010-XXXX-XXXX 형식으로 입력해주세요.');
+    } else {
+      setPhoneError('');
+    }
+  };
+
+  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const email = e.target.value;
+    setFormData({ ...formData, email });
+
+    // 이메일 유효성 검사
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setEmailError('유효한 이메일 주소를 입력해주세요.');
+    } else {
+      setEmailError('');
     }
   };
 
@@ -61,7 +96,8 @@ export default function UserInfo({ onNext, setFormData, formData }: UserInfoProp
         label="이메일"
         placeholder="이메일을 입력해주세요"
         value={formData.email}
-        onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+        onChange={handleEmailChange} // 이메일 변경 핸들러로 수정
+        errorMessage={emailError} // 이메일 오류 메시지 추가
       />
       <Input
         type="text"
@@ -84,8 +120,9 @@ export default function UserInfo({ onNext, setFormData, formData }: UserInfoProp
         type="text"
         label="휴대폰번호"
         placeholder="휴대폰번호를 입력해주세요"
-        value={formData.phone}
-        onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
+        value={formData.phone} // 변경된 값 저장
+        onChange={handlePhoneChange}
+        errorMessage={phoneError}
       />
 
       <div css={fixedButtonWrapper}>

--- a/src/pages/onboarding/index.styles.ts
+++ b/src/pages/onboarding/index.styles.ts
@@ -1,10 +1,8 @@
-import { colors } from '@/styles/colors';
 import theme from '@/styles/theme';
 import { css } from '@emotion/react';
 
 export const wrapper = css`
   width: 100%;
-  padding: 0 0 calc(${theme.size.gnbHeight} + 18px);
   display: flex;
   flex-direction: column;
 `;
@@ -12,26 +10,25 @@ export const wrapper = css`
 export const progressBarContainer = css`
   width: 100%;
   height: 3px;
-  margin-bottom: 20px;
   position: relative;
 `;
 
 export const progressBar = ({ step }: { step: number }) => css`
   width: 33.33%;
   height: 100%;
-  background-color: ${colors.green200};
+  background-color: ${theme.colors.green200};
   transform: translateX(${(step - 1) * 100}%);
   transition: transform 0.3s ease;
 `;
 
 export const skipButton = css`
-  position: absolute;
+  position: relative;
   bottom: 1%;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: ${colors.white};
-  color: ${colors.gray300};
+  background-color: ${theme.colors.white};
+  color: ${theme.colors.gray300};
   width: 100%;
   height: 45px;
   border-radius: 10px;

--- a/src/pages/onboarding/index.styles.ts
+++ b/src/pages/onboarding/index.styles.ts
@@ -26,7 +26,7 @@ export const progressBar = ({ step }: { step: number }) => css`
 
 export const skipButton = css`
   position: absolute;
-  bottom: 23px;
+  bottom: 1%;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -29,8 +29,7 @@ export default function Onboarding() {
   const handleBackNavigation = () => {
     switch (step) {
       case STEPS.PET_TYPE:
-        setStep(STEPS.USER_INFO);
-        break;
+        return;
       case STEPS.PET_NAME:
         setStep(STEPS.PET_TYPE);
         break;
@@ -42,6 +41,8 @@ export default function Onboarding() {
         return;
     }
   };
+  // 버튼의 disabled 상태를 설정하는 조건
+  const isBackButtonDisabled = step === STEPS.PET_TYPE;
 
   const { mutate } = useUsersPetMutation(() => {
     setStep(STEPS.COMPLETE);
@@ -97,7 +98,14 @@ export default function Onboarding() {
   return (
     <Layout>
       <AppBar
-        prefix={<AppBarBack height="24px" cursor="pointer" onClick={handleBackNavigation} />}
+        prefix={
+          <AppBarBack
+            height="24px"
+            cursor={isBackButtonDisabled ? 'not-allowed' : 'pointer'}
+            onClick={handleBackNavigation}
+            disabled={isBackButtonDisabled}
+          />
+        }
       />
       <section css={wrapper}>
         <div css={progressBarContainer}>

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { useUsersPetMutation } from '@/queries/users';
 import { AppBarBack } from '@/assets/icons';
-import { AppBar, Layout, Text } from '@/components';
+import { AppBar, Layout } from '@/components';
 import { Completion, PetName, PetType, UserInfo } from './components';
-import { progressBarContainer, progressBar, skipButton, wrapper } from './index.styles';
+import { progressBarContainer, progressBar, wrapper } from './index.styles';
 import { UserInfoForm } from './types';
+import { useNavigate } from 'react-router-dom';
 
 const STEPS = {
   USER_INFO: 1,
@@ -14,7 +15,8 @@ const STEPS = {
 };
 
 export default function Onboarding() {
-  const [step, setStep] = useState(STEPS.USER_INFO);
+  const navigate = useNavigate();
+  const [step, setStep] = useState<number>(STEPS.USER_INFO);
   const [formData, setFormData] = useState<UserInfoForm>({
     email: '',
     nickname: '',
@@ -22,6 +24,24 @@ export default function Onboarding() {
     petType: null,
     petName: '',
   });
+
+  // Handler to navigate based on the step
+  const handleBackNavigation = () => {
+    switch (step) {
+      case STEPS.PET_TYPE:
+        setStep(STEPS.USER_INFO);
+        break;
+      case STEPS.PET_NAME:
+        setStep(STEPS.PET_TYPE);
+        break;
+      case STEPS.COMPLETE:
+        setStep(STEPS.PET_NAME);
+        break;
+      default:
+        navigate(-1);
+        return;
+    }
+  };
 
   const { mutate } = useUsersPetMutation(() => {
     setStep(STEPS.COMPLETE);
@@ -36,11 +56,7 @@ export default function Onboarding() {
   };
 
   const handleSkipButtonClick = () => {
-    if (step === STEPS.PET_TYPE) {
-      setStep(STEPS.PET_NAME);
-    } else if (step === STEPS.PET_NAME) {
-      setStep(STEPS.COMPLETE);
-    }
+    setStep(STEPS.COMPLETE);
   };
 
   const renderStep = () => {
@@ -59,6 +75,7 @@ export default function Onboarding() {
             formData={formData}
             setFormData={(data) => setFormData({ ...formData, ...data })}
             onNext={handleNextButtonClick}
+            onSkip={handleSkipButtonClick}
           />
         );
       case STEPS.PET_NAME:
@@ -67,6 +84,7 @@ export default function Onboarding() {
             formData={formData}
             setFormData={setFormData}
             onComplete={handleNextButtonClick}
+            onSkip={handleSkipButtonClick}
           />
         );
       case STEPS.COMPLETE:
@@ -78,19 +96,15 @@ export default function Onboarding() {
 
   return (
     <Layout>
-      <AppBar prefix={<AppBarBack height="24px" cursor="pointer" />} />
+      <AppBar
+        prefix={<AppBarBack height="24px" cursor="pointer" onClick={handleBackNavigation} />}
+      />
       <section css={wrapper}>
         <div css={progressBarContainer}>
           <div css={progressBar({ step: step === STEPS.COMPLETE ? 3 : step })} />
         </div>
 
         {renderStep()}
-
-        {(step === STEPS.PET_TYPE || step === STEPS.PET_NAME) && (
-          <div css={skipButton} onClick={handleSkipButtonClick}>
-            <Text typo="body1">건너뛰기</Text>
-          </div>
-        )}
       </section>
     </Layout>
   );

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -34,15 +34,14 @@ export default function Onboarding() {
         setStep(STEPS.PET_TYPE);
         break;
       case STEPS.COMPLETE:
-        setStep(STEPS.PET_NAME);
-        break;
+        return;
       default:
         navigate(-1);
         return;
     }
   };
   // 버튼의 disabled 상태를 설정하는 조건
-  const isBackButtonDisabled = step === STEPS.PET_TYPE;
+  const isBackButtonDisabled = step === STEPS.PET_TYPE || STEPS.COMPLETE;
 
   const { mutate } = useUsersPetMutation(() => {
     setStep(STEPS.COMPLETE);

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useUsersPetMutation } from '@/queries/users';
 import { AppBarBack } from '@/assets/icons';
-import { AppBar, Layout } from '@/components';
+import { AppBar, Layout, Text } from '@/components';
 import { Completion, PetName, PetType, UserInfo } from './components';
 import { progressBarContainer, progressBar, skipButton, wrapper } from './index.styles';
 import { UserInfoForm } from './types';
@@ -88,7 +88,7 @@ export default function Onboarding() {
 
         {(step === STEPS.PET_TYPE || step === STEPS.PET_NAME) && (
           <div css={skipButton} onClick={handleSkipButtonClick}>
-            건너뛰기
+            <Text typo="body1">건너뛰기</Text>
           </div>
         )}
       </section>


### PR DESCRIPTION
### PR 제목

[PREAM-145] 온보딩 페이지 디자인 수정

### 🔗 연관된 이슈 번호

close #107 

### ✨ 어떤 기능을 개발했나요?
**[온보딩 변경사항]**

- **전체적인 디자인 수정하였습니다.**
    1. 반려동물 이름 입력 페이지에서 피그마와 다르게 그 전 페이지의 문구 높이와 같게 설정하였는데 어떤게 나은지 의논이 필요할 것 같습니다.
    2. 반려동물 타입 선택 시 테두리 뿐만 아니라 배경색을 green100으로 주었습니다.
    3. skip 버튼을 pet-type, pet-name 컴포넌트로 이동하였습니다.
- **User Info 유효성 검사**
    1. 전화번호 : 대시(-)를 사용하지 않고 자동 포맷팅(010-xxxx-xxxx)되게 변경하였고, 숫자만 입력할 수 있게 하였습니다.
    2. 닉네임: 중복체크 뿐만아니라 2~20자 이내로 입력해야하는 유효성 검사 추가하였습니다.
- **Pet Name 유효성 검사**
    1. 반려동물 이름: 2~20자 이내로 입력해야하는 유효성 검사 추가하였습니다. (한 글자인 반려동물 이름이 있으면,,?)
- **뒤로가기 기능 추가했습니다.**
- **pet-type, pet-name에서 skip 버튼 클릭 시 모두 회원가입 완료로(Completion)로 이동합니다.**

### ✅ 어떤 문제를 해결했나요?

### 🗂️ 논의 사항
- **뒤로가기 기능** 
    1. 사용자 정보 입력 후 펫 타입 선택 페이지에서 뒤로 가면 사용자 정보가 저장되었기 때문에 유효성 검사에서 막히게 되어 다음으로 넘어가지지 않습니다..(어떻게 해야할지?)
    2. Completion에서도 이미 반려동물 프로필이 등록되었기 때문에 마찬가지 입니다.



[PREAM-145]: https://team-pream.atlassian.net/browse/PREAM-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ