### PR TITLE
[PREAM-81] 판매 내역 페이지, 메인페이지 경로 연결 영역 수정

### DIFF
--- a/src/pages/main/index.styles.ts
+++ b/src/pages/main/index.styles.ts
@@ -44,6 +44,7 @@ export const itemList = css`
 export const item = css`
   display: flex;
   flex-direction: column;
+  cursor: pointer;
 `;
 
 export const imageBox = css`
@@ -73,7 +74,6 @@ export const textBox = css`
   flex-direction: column;
   gap: 6px;
   padding: 8px 0 0 7px;
-  cursor: pointer;
 `;
 
 export const itemTitle = css`

--- a/src/pages/mypage/pages/sales-list/index.style.ts
+++ b/src/pages/mypage/pages/sales-list/index.style.ts
@@ -24,6 +24,7 @@ export const content = css`
   display: flex;
   gap: 20px;
   width: 100%;
+  cursor: pointer;
 `;
 
 export const opacityBox = (props: string) => css`
@@ -68,7 +69,6 @@ export const bottomBox = css`
   display: flex;
   flex-direction: column;
   gap: 7px;
-  cursor: pointer;
 `;
 
 export const salesStatus = css`

--- a/src/pages/mypage/pages/sales-list/index.tsx
+++ b/src/pages/mypage/pages/sales-list/index.tsx
@@ -33,7 +33,7 @@ export default function SalesList() {
         </div>
         {data?.map((listData) => (
           <div css={item} key={listData.id}>
-            <div css={content}>
+            <div css={content} onClick={() => navigate(`/products/${listData.id}`)}>
               <div css={opacityBox(listData.status)}>
                 {listData.status === 'AVAILABLE' ? (
                   ''
@@ -68,7 +68,7 @@ export default function SalesList() {
                   </Text>
                   <Text typo="body1">{listData.createdAt.substring(2, 10).replace(/-/g, '.')}</Text>
                 </div>
-                <div css={bottomBox} onClick={() => navigate(`/products/${listData.id}`)}>
+                <div css={bottomBox}>
                   <Text typo="body2" css={contentTitle}>
                     {listData.title}
                   </Text>

--- a/src/queries/query-keys.ts
+++ b/src/queries/query-keys.ts
@@ -14,5 +14,8 @@ export const QUERY_KEYS = {
   DELETE_PRODUCTS_DETAIL: (productId: string) => ['DELETE_PRODUCTS_DETAIL', productId],
   GET_PRODUCTS_SEARCH: (params: GetProductsSearchParam) => ['GET_PRODUCTS_SEARCH', params],
   GET_SALES_LIST: ['GET_SALES_LIST'],
+<<<<<<< HEAD
   GET_ADDRESS_ME: ['GET_ADDRESS_ME'],
+=======
+>>>>>>> 3e3b7ae ([PREAM-101] 판매내역 페이지 개발 완료 (#102))
 } as const;

--- a/src/queries/query-keys.ts
+++ b/src/queries/query-keys.ts
@@ -14,8 +14,5 @@ export const QUERY_KEYS = {
   DELETE_PRODUCTS_DETAIL: (productId: string) => ['DELETE_PRODUCTS_DETAIL', productId],
   GET_PRODUCTS_SEARCH: (params: GetProductsSearchParam) => ['GET_PRODUCTS_SEARCH', params],
   GET_SALES_LIST: ['GET_SALES_LIST'],
-<<<<<<< HEAD
   GET_ADDRESS_ME: ['GET_ADDRESS_ME'],
-=======
->>>>>>> 3e3b7ae ([PREAM-101] 판매내역 페이지 개발 완료 (#102))
 } as const;


### PR DESCRIPTION
### PR 제목

[PREAM-81] 판매 내역 페이지, 메인페이지 경로 연결 영역 수정

### 🔗 연관된 이슈 번호

close #127 

### ✨ 어떤 기능을 개발했나요?

### ✅ 어떤 문제를 해결했나요?
- 판매 내역 페이지 내 각 상품들의 이미지도 선택이 가능하도록 선택 범위를 수정했습니다.
- 메인 페이지 내 각 상품들의 이미지도 선택이 가능하도록 선택 범위를 수정했습니다.

### 🗂️ 관련 논의 내용 Link (Option)

### 🚀 결과 이미지 (Option)


[PREAM-81]: https://team-pream.atlassian.net/browse/PREAM-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ