### PR TITLE
[PREAM-172] 상품 목록 썸네일 이미지 사이즈 통일

### DIFF
--- a/src/pages/products/pages/list/index.styles.ts
+++ b/src/pages/products/pages/list/index.styles.ts
@@ -56,12 +56,14 @@ export const item = css`
 export const imageBox = css`
   position: relative;
   cursor: pointer;
+  height: -webkit-fill-available;
 `;
 
 export const image = css`
   border-radius: 13px;
   width: 100%;
   height: 100%;
+  object-fit: cover;
 `;
 
 export const opacityBox = css`


### PR DESCRIPTION
### PR 제목

[PREAM-172] 상품 목록 썸네일 이미지 사이즈 통일

### 🔗 연관된 이슈 번호

close #146 

### ✨ 어떤 기능을 개발했나요?

### ✅ 어떤 문제를 해결했나요?
- 새로운 상품을 판매 등록했을 때 상품 목록 페이지에서 상품이 일정한 사이즈로 나오도록 구현했습니다.

### 🗂️ 관련 논의 내용 Link (Option)

### 🚀 결과 이미지 (Option)


[PREAM-172]: https://team-pream.atlassian.net/browse/PREAM-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ