### PR TITLE
[PREAM-174] 판매 등록 페이지 수수료 계산 및 툴팁 구현

### DIFF
--- a/public/icons/tool_tip.svg
+++ b/public/icons/tool_tip.svg
@@ -1,0 +1,5 @@
+<svg width="11" height="11" viewBox="0 0 11 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="5.5" cy="5.5" r="5.5" fill="#D9D9D9"/>
+<circle cx="5.5" cy="3.5" r="0.5" fill="white"/>
+<rect x="5" y="5" width="1" height="3" rx="0.5" fill="white"/>
+</svg>

--- a/src/assets/icons/ToolTip.tsx
+++ b/src/assets/icons/ToolTip.tsx
@@ -1,0 +1,9 @@
+import type { SVGProps } from 'react';
+const SvgToolTip = (props: SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 11 11" {...props}>
+    <circle cx={5.5} cy={5.5} r={5.5} fill="#D9D9D9" />
+    <circle cx={5.5} cy={3.5} r={0.5} fill="#fff" />
+    <rect width={1} height={3} x={5} y={5} fill="#fff" rx={0.5} />
+  </svg>
+);
+export default SvgToolTip;

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -17,4 +17,5 @@ export { default as ProductsDetailOption } from './ProductsDetailOption';
 export { default as Search } from './Search';
 export { default as SelectCat } from './SelectCat';
 export { default as SelectDog } from './SelectDog';
+export { default as ToolTip } from './ToolTip';
 export { default as UploadPlus } from './UploadPlus';

--- a/src/pages/products/components/form/index.styles.ts
+++ b/src/pages/products/components/form/index.styles.ts
@@ -18,7 +18,7 @@ export const wrap = css`
 export const hr = css`
   width: calc(100% - 36px);
   height: 2px;
-  margin: 32px auto 19px auto;
+  margin: 19px auto 18px auto;
 `;
 
 export const productInfo = css`
@@ -51,4 +51,48 @@ export const fixedCTAButtonWrapper = css`
   min-width: ${theme.size.minWidth};
   max-width: ${theme.size.maxWidth};
   margin: 0 auto;
+`;
+
+export const amount = css`
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  margin-top: 11px;
+`;
+
+export const toolTip = css`
+  cursor: pointer;
+  position: relative;
+  display: flex;
+
+  &:hover > div {
+    opacity: 1;
+    visibility: visible;
+  }
+`;
+
+export const toolTipInfo = css`
+  opacity: 0;
+  visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  position: absolute;
+  width: 322px;
+  padding: 16px;
+  top: calc(100% + 8px);
+  left: 100px;
+  transform: translateX(-50%);
+  background-color: white;
+  border-radius: 12px;
+  z-index: 2;
+  box-shadow: 0 0 6px rgba(0, 0, 6, 0.1);
+  transition:
+    opacity 0.2s ease,
+    visibility 0.2s ease;
+`;
+
+export const amountPrice = css`
+  display: flex;
+  align-items: center;
 `;


### PR DESCRIPTION
### PR 제목

[PREAM-174] 판매 등록 페이지 수수료 계산 및 툴팁 구현

### 🔗 연관된 이슈 번호

close #152 

### ✨ 어떤 기능을 개발했나요?
- 판매 희망가에서 3.5%의 수수료를 뗀 예상 정산 금액을 계산해 보여주었습니다.
- 판매 수수료 툴팁  박스를 구현했습니다.

### ✅ 어떤 문제를 해결했나요?

### 🗂️ 관련 논의 내용 Link (Option)

### 🚀 결과 이미지 (Option)
<img width="396" alt="스크린샷 2024-11-07 오전 1 35 59" src="https://github.com/user-attachments/assets/afb2a572-0cac-40bb-86e4-f014574c9864">


[PREAM-174]: https://team-pream.atlassian.net/browse/PREAM-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ