### PR TITLE
[PREAM-172] 상품 목록 썸네일 이미지 사이즈 수정

### DIFF
--- a/src/pages/products/pages/list/index.styles.ts
+++ b/src/pages/products/pages/list/index.styles.ts
@@ -56,7 +56,7 @@ export const item = css`
 export const imageBox = css`
   position: relative;
   cursor: pointer;
-  height: -webkit-fill-available;
+  aspect-ratio: 1;
 `;
 
 export const image = css`


### PR DESCRIPTION
### PR 제목

[PREAM-172] 상품 목록 썸네일 이미지 사이즈 수정

### 🔗 연관된 이슈 번호

close #154 

### ✨ 어떤 기능을 개발했나요?

### ✅ 어떤 문제를 해결했나요?
- 게시글 제목이 한줄인 경우 썸네일 이미지의 세로사이즈가 좀 더 길게 나오는 문제가 있었습니다.
  - `aspect-ratio`를 사용해 비율이 일정하게 유지되도록 수정했습니다.

### 🗂️ 관련 논의 내용 Link (Option)

### 🚀 결과 이미지 (Option)
<img width="427" alt="스크린샷 2024-11-07 오전 11 27 38" src="https://github.com/user-attachments/assets/023405a2-4a5a-4656-8fab-949021ae73d0">


[PREAM-172]: https://team-pream.atlassian.net/browse/PREAM-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ