### PR TITLE
[PREAM-164] 검색 페이지 예약 중 표시 UI 추가

### DIFF
--- a/src/pages/products/pages/search/index.tsx
+++ b/src/pages/products/pages/search/index.tsx
@@ -127,6 +127,7 @@ export default function Search() {
           <div css={itemList}>
             {data?.products.map((product: ProductListProduct) => {
               const isSoldOut = product.status === 'SOLD_OUT';
+              const isReserved = product.status === 'RESERVED';
               const price = product.price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ','); //천 단위 콤마
               return (
                 <div
@@ -141,6 +142,13 @@ export default function Search() {
                       <div css={soldOutOverlayStyle}>
                         <Text typo="body1" color={theme.colors.white}>
                           판매완료
+                        </Text>
+                      </div>
+                    )}
+                    {isReserved && (
+                      <div css={soldOutOverlayStyle}>
+                        <Text typo="body1" color={theme.colors.white}>
+                          예약 중
                         </Text>
                       </div>
                     )}


### PR DESCRIPTION
### PR 제목

[PREAM-164] 검색 페이지 예약 중 표시 UI 추가

### 🔗 연관된 이슈 번호

close #159 

### ✨ 어떤 기능을 개발했나요?

### ✅ 어떤 문제를 해결했나요?
- 검색 페이지에서 예약중인 상품은 예약 중이라고 보이게 했습니다.

### 🗂️ 관련 논의 내용 Link (Option)

### 🚀 결과 이미지 (Option)
<img width="482" alt="image" src="https://github.com/user-attachments/assets/6005f4ff-b95d-4ff5-b7a4-4643d51b30fa">


[PREAM-164]: https://team-pream.atlassian.net/browse/PREAM-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ